### PR TITLE
Fixed a bug where ids list was populated with dictionaries instead of id values.

### DIFF
--- a/scripts/rigid_bodies_publisher.py
+++ b/scripts/rigid_bodies_publisher.py
@@ -32,7 +32,7 @@ class RigidBodiesPublisher(object):
     ids = []
     for name,value in rigid_bodies.items():
       names.append(name)
-      ids.append(value)
+      ids.append(value["id"])
     # Setup Publishers
     pose_pub = rospy.Publisher('/optitrack/rigid_bodies', RigidBodyArray, queue_size=3)
     # Setup TF listener and broadcaster
@@ -69,7 +69,7 @@ class RigidBodiesPublisher(object):
         version = packet.natnet_version
         rospy.loginfo('NatNet version received: ' + str(version))
       if type(packet) in [rx.SenderData, rx.ModelDefs, rx.FrameOfData]:
-        # Optitrack gives the position of the centroid. 
+        # Optitrack gives the position of the centroid.
         array_msg = RigidBodyArray()
         for i, rigid_body in enumerate(packet.rigid_bodies):
           body_id = rigid_body.id


### PR DESCRIPTION
```python
     for name,value in rigid_bodies.items():
         names.append(name)
         ids.append(value)
```
`value` is actually a dictionary and not int, example:: 
```
{'id': 2, 'markers': [[22.378, -0.158, -10.189], [-25.409, 114.359, 2.92], [13.729, 114.186, 2.757], [-24.982, -114.268, 2.381], [14.284, -114.119, 2.131]], 'name': 'Test'}
```